### PR TITLE
Map chunked items to a string

### DIFF
--- a/raven_sh.py
+++ b/raven_sh.py
@@ -159,7 +159,7 @@ def string_to_chunks(name, string, max_chars=400):
 
     # final action: close current chunk
     if chunk_items:
-        chunks.append('\n'.join(chunk_items))
+        chunks.append('\n'.join(map(str, chunk_items)))
 
     # format output
     if not chunks:


### PR DESCRIPTION
I'm currently getting the following error when consuming a python cron:
    `
    chunks.append('\n'.join(chunk_items))
    TypeError: sequence item 0: expected str instance, bytes found
`

Mapping the array to `str` seems to work. 
