### PR TITLE
Add environment as a configuration option

### DIFF
--- a/raven_sh.py
+++ b/raven_sh.py
@@ -76,6 +76,10 @@ class Runner(object):
 
         parser.add_option('--message', help='Message string to send to sentry '
                                             '(optional)')
+        parser.add_option('--environment', dest='environment',
+                          help='Deploy environment. Alternatively setup '
+                               'SENTRY_ENVIRONMENT environment variable')
+
         return parser
 
     def run(self):
@@ -122,6 +126,7 @@ class Runner(object):
 
     def get_raven(self):
         dsn = self.opts.dsn or os.getenv('SENTRY_DSN')
+        environment = self.opts.environment or os.getenv('SENTRY_ENVIRONMENT', 'production')
         error_msg = 'Neither --dsn option or SENTRY_DSN env variable defined'
 
         if not dsn and self.opts.debug:
@@ -131,7 +136,7 @@ class Runner(object):
         if not dsn:
             raise SystemExit(error_msg)
 
-        return raven.Client(dsn=dsn)
+        return raven.Client(dsn=dsn, environment=environment)
 
 
 def string_to_chunks(name, string, max_chars=400):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=read('README.rst'),
     py_modules=['raven_sh'],
     install_requires=[
-        'raven',
+        'raven>=5.9.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Sentry now supports displaying deploy environment information (i.e. staging,
production, etc.). This adds it as either a CLI option or an environment
variable SENTRY_ENVIRONMENT.
