### PR TITLE
Migrate to sentry-sdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ setup(
     version='0.4',
     author='Roman Imankulov',
     author_email='roman.imankulov@gmail.com',
-    url='http://github.com/doist/raven-sh',
+    url='https://github.com/doist/raven-sh',
     description='raven-sh is a client for Sentry which can be used as '
                 'a wrapper for cron jobs',
     long_description=read('README.rst'),
     py_modules=['raven_sh'],
     install_requires=[
-        'raven>=5.9.0',
+        'sentry-sdk>=0.7.10',
     ],
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35
+envlist = py27, py37
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Sadly there is no equivalent to `raven.utils.json` in the new Sentry SDK :(